### PR TITLE
SA-1 For NestJs based projects env vars are not set at a time of importing libs

### DIFF
--- a/src/pubsub.js
+++ b/src/pubsub.js
@@ -2,15 +2,26 @@ const EventEmitter = require("events");
 const logger = require("./helper/logger");
 const {clientFactory} = require("./adapter/clientFactory");
 
-const mqClient = clientFactory.createClient();
-
 const topicsMap = new Map();
 const topicsWaiting = new Map();
 
 class TopicEmitter extends EventEmitter {}
 const topicEmitter = new TopicEmitter();
 
+const getMqClient = (function() {
+    let mqClient = null;
+
+    return async function () {
+        if (!mqClient) {
+            mqClient = clientFactory.createClient();
+        }
+        return mqClient;
+    }
+})();
+
 async function getTopic(topicName) {
+    const mqClient = await getMqClient();
+
     if (topicsMap.has(topicName)) {
         return mqClient.topic(topicName);
     }


### PR DESCRIPTION
When using this approach of Nest Js then process.env.xxx var is not set at the moment of importing lib:
https://docs.nestjs.com/techniques/configuration
`import { publish } from '@dasmeta/event-manager-node-api';`